### PR TITLE
Fix Future lifetime for spawn

### DIFF
--- a/src/local_executor.rs
+++ b/src/local_executor.rs
@@ -36,6 +36,7 @@ pub use async_task::Task;
 use crate::{borrow, borrow_mut};
 
 /// A thread-local executor.
+#[derive(Clone)]
 pub struct LocalExecutor {
     /// The executor state.
     state: Rc<State>,
@@ -83,7 +84,7 @@ impl LocalExecutor {
     }
 
     /// Spawns a task onto the executor.
-    pub fn spawn<T>(&self, future: impl Future<Output = T>) -> Task<T> {
+    pub fn spawn<T>(&self, future: impl Future<Output = T> + 'static) -> Task<T> {
         let mut active = borrow_mut!(self.state.active);
 
         // Remove the task from the set of active tasks when the future finishes.

--- a/src/stubs.rs
+++ b/src/stubs.rs
@@ -1,5 +1,5 @@
 use crate::local_executor;
-use crate::ptr::CamlRef;
+use crate::ptr::{CamlRef, CamlRet};
 use crate::util::{ambient_gc, ensure_rooted_value};
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -38,7 +38,7 @@ type Executor = local_executor::LocalExecutor;
 
 #[ocaml::func]
 #[ocaml::sig("int -> executor")]
-pub fn lwti_executor_create(notify_id: isize) -> CamlRef<Executor> {
+pub fn lwti_executor_create(notify_id: isize) -> CamlRet<Executor> {
     let mut executor = Executor::new();
     executor.set_notifier(crate::notification::Notification(notify_id));
     executor.into()


### PR DESCRIPTION
See https://users.rust-lang.org/t/restrict-reference-from-being-borrowed-by-async-weird-segfault-in-ocaml-rust-interop/95636/3