### PR TITLE
[Test] Add Alcotest suite and benchmark separation

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -16,9 +16,7 @@
   dune
   conf-rust-2021
   (rust-staticlib-gen
-   (and
-    (>= 0.2.2)
-    :with-test))
+   (>= 0.2.2))
   (rust-staticlib-virtual
    (>= 0.2.2))
   (dune-cargo-build
@@ -35,6 +33,10 @@
    (and
     (>= 5.8.0)
     (< 6.0.0)))
+  (alcotest
+   (>= 1.9.0))
+  (alcotest-lwt
+   (>= 1.9.0))
   (ocamlformat
    (and
     :with-test

--- a/rust-async.opam
+++ b/rust-async.opam
@@ -9,12 +9,14 @@ bug-reports: "https://github.com/Lupus/ocaml-lwt-interop/issues"
 depends: [
   "dune" {>= "3.7"}
   "conf-rust-2021"
-  "rust-staticlib-gen" {>= "0.2.2" & with-test}
+  "rust-staticlib-gen" {>= "0.2.2"}
   "rust-staticlib-virtual" {>= "0.2.2"}
   "dune-cargo-build" {>= "0.2.2" & build}
   "ocaml-rs-smartptr" {>= "0.1.0"}
   "lwt" {>= "5.6.0" & < "6.0.0"}
   "lwt_ppx" {>= "5.8.0" & < "6.0.0"}
+  "alcotest" {>= "1.9.0"}
+  "alcotest-lwt" {>= "1.9.0"}
   "ocamlformat" {with-test & >= "0.26.2" & < "0.27.0"}
   "odoc" {with-doc}
 ]

--- a/test-stubs/src/lib.rs
+++ b/test-stubs/src/lib.rs
@@ -60,6 +60,15 @@ pub fn lwti_tests_test_sync_call(f: OCamlFunc<(), ()>) {
     join_handle.await.unwrap();
 }
 
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn lwti_tests_spawn_lwt(val: i64) -> ocaml_lwt_interop::promise::Promise<i64> {
+    ocaml_lwt_interop::domain_executor::spawn_lwt(gc, async move {
+        future::yield_now().await;
+        val + 1
+    })
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 //////////               OCaml bindings generation                   //////////
 ///////////////////////////////////////////////////////////////////////////////
@@ -70,5 +79,6 @@ ocaml_gen_bindings! {
         decl_func!(lwti_tests_test1 => "test_1");
         decl_func!(lwti_tests_test2 => "test_2");
         decl_func!(lwti_tests_test_sync_call => "test_sync_call");
+        decl_func!(lwti_tests_spawn_lwt => "spawn_lwt");
     });
 }

--- a/test/Stubs.ml
+++ b/test/Stubs.ml
@@ -3,4 +3,5 @@ module Tests = struct
   external test_1 : unit -> unit Lwt.t = "lwti_tests_test1"
   external test_2 : (unit -> unit Lwt.t) -> unit Lwt.t = "lwti_tests_test2"
   external test_sync_call : (unit -> unit) -> unit Lwt.t = "lwti_tests_test_sync_call"
+  external spawn_lwt : int64 -> int64 Lwt.t = "lwti_tests_spawn_lwt"
 end

--- a/test/benchmark.ml
+++ b/test/benchmark.ml
@@ -1,0 +1,151 @@
+open Stubs
+
+let main_rust () =
+  print_endline "";
+  print_endline "running Lwt+Rust test";
+  let start = Unix.gettimeofday () in
+  let pause = Lwt_unix.auto_pause 0.1 in
+  let page = ref 0 in
+  let rec aux x =
+    let%lwt () = Tests.bench () in
+    page := x;
+    let%lwt () = pause () in
+    aux (x + 1)
+  in
+  let test () = Lwt.async (fun () -> aux 0) in
+  test ();
+  print_endline "lwt sleeping";
+  let%lwt () = Lwt_unix.sleep 10.0 in
+  let finish = Unix.gettimeofday () in
+  Printf.printf
+    "%.3f iterations per second, %d iterations total [Rust+Lwt]\n"
+    (float_of_int !page /. (finish -. start))
+    !page;
+  print_endline "lwt main returning";
+  Lwt.return ()
+;;
+
+let main_rust_slow () =
+  print_endline "";
+  print_endline "running Lwt+Rust (slow) test";
+  let start = Unix.gettimeofday () in
+  let pause = Lwt_unix.auto_pause 0.1 in
+  let page = ref 0 in
+  let rec aux x =
+    let%lwt () =
+      Tests.test_2 (fun () ->
+        page := x;
+        pause ())
+    in
+    aux (x + 1)
+  in
+  let test () = Lwt.async (fun () -> aux 0) in
+  test ();
+  print_endline "lwt sleeping";
+  let%lwt () = Lwt_unix.sleep 10.0 in
+  let finish = Unix.gettimeofday () in
+  Printf.printf
+    "%.3f iterations per second, %d iterations total [Rust(slow)+Lwt]\n"
+    (float_of_int !page /. (finish -. start))
+    !page;
+  print_endline "lwt main returning";
+  Lwt.return ()
+;;
+
+let main_gc () =
+  print_endline "";
+  print_endline "running GC smoke test";
+  let start = Unix.gettimeofday () in
+  let page = ref 0 in
+  let rec aux x =
+    let%lwt () =
+      Tests.test_2 (fun () ->
+        Gc.full_major ();
+        page := x;
+        Gc.full_major ();
+        let%lwt () = Lwt.pause () in
+        Gc.full_major ();
+        Lwt.return ())
+    in
+    Gc.full_major ();
+    aux (x + 1)
+  in
+  let test () = Lwt.async (fun () -> aux 0) in
+  test ();
+  print_endline "lwt sleeping";
+  Gc.full_major ();
+  let%lwt () = Lwt_unix.sleep 10.0 in
+  let finish = Unix.gettimeofday () in
+  Printf.printf
+    "%.3f iterations per second, %d iterations total [GC smoke]\n"
+    (float_of_int !page /. (finish -. start))
+    !page;
+  print_endline "exiting test function (pending GC in 0.5 seconds)";
+  let fut = Lwt_unix.sleep 0.5 in
+  Lwt.on_success fut (fun () ->
+    print_endline "final GC run";
+    Gc.full_major ());
+  fut
+;;
+
+let main_lwt () =
+  print_endline "";
+  print_endline "running Lwt-only baseline";
+  let start = Unix.gettimeofday () in
+  let page = ref 0 in
+  let pause = Lwt_unix.auto_pause 0.1 in
+  let rec aux f x =
+    let%lwt () = Sys.opaque_identity (f x) in
+    aux f (x + 1)
+  in
+  let test ~f = Lwt.async (fun () -> aux f 0) in
+  test ~f:(fun p ->
+    page := p;
+    pause ());
+  print_endline "lwt sleeping";
+  let%lwt () = Lwt_unix.sleep 10.0 in
+  let finish = Unix.gettimeofday () in
+  Printf.printf
+    "%.3f iterations per second, %d iterations total [Only Lwt]\n"
+    (float_of_int !page /. (finish -. start))
+    !page;
+  print_endline "lwt main returning";
+  Lwt.return ()
+;;
+
+let main_sync () =
+  print_endline "";
+  print_endline "running Sync func call test";
+  let start = Unix.gettimeofday () in
+  let page = ref 0 in
+  let rec aux f x =
+    let%lwt () = f x in
+    if x = 50_000 then Lwt.return () else aux f (x + 1)
+  in
+  let test p =
+    let%lwt () = Tests.test_sync_call (fun () -> page := p) in
+    Lwt.return ()
+  in
+  print_endline "running the test";
+  let%lwt () = aux test 0 in
+  let finish = Unix.gettimeofday () in
+  Printf.printf
+    "%.3f iterations per second, %d iterations total [Sync func call]\n"
+    (float_of_int !page /. (finish -. start))
+    !page;
+  print_endline "test main returning";
+  Lwt.return ()
+;;
+
+let () =
+  Lwt_main.run
+    (match Sys.argv with
+     | [| _; "lwt" |] -> main_lwt ()
+     | [| _; "rust" |] -> main_rust ()
+     | [| _; "rust-slow" |] -> main_rust_slow ()
+     | [| _; "gc" |] -> main_gc ()
+     | [| _; "sync" |] -> main_sync ()
+     | [| _ |] ->
+       failwith "no command provided on command line - should be one of: lwt, rust, gc"
+     | _ -> failwith "unknown command line arguments")
+;;

--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,27 @@
+(library
+ (name test_stubs)
+ (wrapped false)
+ (modules Stubs)
+ (libraries rust_async_stubs lwt))
+
+(executable
+ (name benchmark)
+ (modules benchmark)
+ (libraries unix lwt.unix rust-async rust_async_stubs test_stubs)
+ (preprocess
+  (pps lwt_ppx)))
+
 (executable
  (name test)
- (libraries unix lwt.unix rust-async rust_async_stubs)
+ (modules test)
+ (libraries
+  unix
+  lwt.unix
+  alcotest
+  alcotest-lwt
+  rust-async
+  rust_async_stubs
+  test_stubs)
  (preprocess
   (pps lwt_ppx)))
 
@@ -16,10 +37,15 @@
   (diff Stubs.ml Stubs.ml.new)))
 
 (rule
- (alias runtest)
+ (alias benchmark)
  (action
   (progn
-   (run ./test.exe lwt)
-   (run ./test.exe rust)
-   (run ./test.exe rust-slow)
-   (run ./test.exe gc))))
+   (run ./benchmark.exe lwt)
+   (run ./benchmark.exe rust)
+   (run ./benchmark.exe rust-slow)
+   (run ./benchmark.exe gc))))
+
+(rule
+ (alias runtest)
+ (action
+  (run ./test.exe)))

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,151 +1,37 @@
+open Alcotest
+open Alcotest_lwt
+open Lwt.Infix
 open Stubs
 
-let main_rust () =
-  print_endline "";
-  print_endline "running Lwt+Rust test";
-  let start = Unix.gettimeofday () in
-  let pause = Lwt_unix.auto_pause 0.1 in
-  let page = ref 0 in
-  let rec aux x =
-    let%lwt () = Tests.bench () in
-    page := x;
-    let%lwt () = pause () in
-    aux (x + 1)
-  in
-  let test () = Lwt.async (fun () -> aux 0) in
-  test ();
-  print_endline "lwt sleeping";
-  let%lwt () = Lwt_unix.sleep 10.0 in
-  let finish = Unix.gettimeofday () in
-  Printf.printf
-    "%.3f iterations per second, %d iterations total [Rust+Lwt]\n"
-    (float_of_int !page /. (finish -. start))
-    !page;
-  print_endline "lwt main returning";
-  Lwt.return ()
+let test_bench _ () = Tests.bench () >|= fun () -> ()
+let test_test1 _ () = Tests.test_1 () >|= fun () -> ()
+let test_test2 _ () = Tests.test_2 (fun () -> Lwt.return_unit) >|= fun () -> ()
+
+let test_sync_call _ () =
+  let called = ref false in
+  Tests.test_sync_call (fun () -> called := true)
+  >>= fun () ->
+  check bool "callback called" true !called;
+  Lwt.return_unit
 ;;
 
-let main_rust_slow () =
-  print_endline "";
-  print_endline "running Lwt+Rust (slow) test";
-  let start = Unix.gettimeofday () in
-  let pause = Lwt_unix.auto_pause 0.1 in
-  let page = ref 0 in
-  let rec aux x =
-    let%lwt () =
-      Tests.test_2 (fun () ->
-        page := x;
-        pause ())
-    in
-    aux (x + 1)
-  in
-  let test () = Lwt.async (fun () -> aux 0) in
-  test ();
-  print_endline "lwt sleeping";
-  let%lwt () = Lwt_unix.sleep 10.0 in
-  let finish = Unix.gettimeofday () in
-  Printf.printf
-    "%.3f iterations per second, %d iterations total [Rust(slow)+Lwt]\n"
-    (float_of_int !page /. (finish -. start))
-    !page;
-  print_endline "lwt main returning";
-  Lwt.return ()
-;;
-
-let main_gc () =
-  print_endline "";
-  print_endline "running GC smoke test";
-  let start = Unix.gettimeofday () in
-  let page = ref 0 in
-  let rec aux x =
-    let%lwt () =
-      Tests.test_2 (fun () ->
-        Gc.full_major ();
-        page := x;
-        Gc.full_major ();
-        let%lwt () = Lwt.pause () in
-        Gc.full_major ();
-        Lwt.return ())
-    in
-    Gc.full_major ();
-    aux (x + 1)
-  in
-  let test () = Lwt.async (fun () -> aux 0) in
-  test ();
-  print_endline "lwt sleeping";
-  Gc.full_major ();
-  let%lwt () = Lwt_unix.sleep 10.0 in
-  let finish = Unix.gettimeofday () in
-  Printf.printf
-    "%.3f iterations per second, %d iterations total [GC smoke]\n"
-    (float_of_int !page /. (finish -. start))
-    !page;
-  print_endline "exiting test function (pending GC in 0.5 seconds)";
-  let fut = Lwt_unix.sleep 0.5 in
-  Lwt.on_success fut (fun () ->
-    print_endline "final GC run";
-    Gc.full_major ());
-  fut
-;;
-
-let main_lwt () =
-  print_endline "";
-  print_endline "running Lwt-only baseline";
-  let start = Unix.gettimeofday () in
-  let page = ref 0 in
-  let pause = Lwt_unix.auto_pause 0.1 in
-  let rec aux f x =
-    let%lwt () = Sys.opaque_identity (f x) in
-    aux f (x + 1)
-  in
-  let test ~f = Lwt.async (fun () -> aux f 0) in
-  test ~f:(fun p ->
-    page := p;
-    pause ());
-  print_endline "lwt sleeping";
-  let%lwt () = Lwt_unix.sleep 10.0 in
-  let finish = Unix.gettimeofday () in
-  Printf.printf
-    "%.3f iterations per second, %d iterations total [Only Lwt]\n"
-    (float_of_int !page /. (finish -. start))
-    !page;
-  print_endline "lwt main returning";
-  Lwt.return ()
-;;
-
-let main_sync () =
-  print_endline "";
-  print_endline "running Sync func call test";
-  let start = Unix.gettimeofday () in
-  let page = ref 0 in
-  let rec aux f x =
-    let%lwt () = f x in
-    if x = 50_000 then Lwt.return () else aux f (x + 1)
-  in
-  let test p =
-    let%lwt () = Tests.test_sync_call (fun () -> page := p) in
-    Lwt.return ()
-  in
-  print_endline "running the test";
-  let%lwt () = aux test 0 in
-  let finish = Unix.gettimeofday () in
-  Printf.printf
-    "%.3f iterations per second, %d iterations total [Sync func call]\n"
-    (float_of_int !page /. (finish -. start))
-    !page;
-  print_endline "test main returning";
-  Lwt.return ()
+let test_spawn_lwt _ () =
+  Tests.spawn_lwt 41L
+  >>= fun v ->
+  check int64 "value" 42L v;
+  Lwt.return_unit
 ;;
 
 let () =
   Lwt_main.run
-    (match Sys.argv with
-     | [| _; "lwt" |] -> main_lwt ()
-     | [| _; "rust" |] -> main_rust ()
-     | [| _; "rust-slow" |] -> main_rust_slow ()
-     | [| _; "gc" |] -> main_gc ()
-     | [| _; "sync" |] -> main_sync ()
-     | [| _ |] ->
-       failwith "no command provided on command line - should be one of: lwt, rust, gc"
-     | _ -> failwith "unknown command line arguments")
+    (run
+       "ocaml-lwt-interop"
+       [ ( "basic"
+         , [ test_case "bench" `Quick test_bench
+           ; test_case "test1" `Quick test_test1
+           ; test_case "test2" `Quick test_test2
+           ; test_case "sync_call" `Quick test_sync_call
+           ; test_case "spawn_lwt" `Quick test_spawn_lwt
+           ] )
+       ])
 ;;


### PR DESCRIPTION
## Summary
- convert old OCaml test driver into benchmark
- add Alcotest_lwt based test suite exercising Rust stubs
- expose new Rust stub to spawn_lwt
- update dune rules for benchmarks and tests

## Testing Done
- `cargo test --offline`
- `opam exec -- dune build`
- `opam exec -- dune runtest`
