### PR TITLE
[test] expand async integration coverage

### DIFF
--- a/test-stubs/src/lib.rs
+++ b/test-stubs/src/lib.rs
@@ -69,6 +69,68 @@ pub fn lwti_tests_spawn_lwt(val: i64) -> ocaml_lwt_interop::promise::Promise<i64
     })
 }
 
+#[ocaml_lwt_interop::func]
+#[ocaml_gen::func]
+pub fn lwti_tests_run_in_ocaml_domain(f: OCamlFunc<(), ()>) -> () {
+    let handle = domain_executor::handle();
+    let join_handle = tokio::spawn(async move {
+        future::yield_now().await;
+        unsafe { run_in_ocaml_domain(&handle, move |gc| f.call(gc, ())) };
+    });
+    join_handle.await.unwrap();
+}
+
+#[ocaml_lwt_interop::func]
+#[ocaml_gen::func]
+pub fn lwti_tests_handle(f: OCamlAsyncFunc<(), ()>) -> () {
+    let handle = domain_executor::handle();
+    let join_handle = tokio::spawn(async move {
+        future::yield_now().await;
+        let task =
+            handle.spawn(async move { f.call(()).await.map_err(|e| e.to_string()) });
+        task.await.expect("ocaml task failed");
+    });
+    join_handle.await.unwrap();
+}
+
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn lwti_tests_promise_create(val: i64) -> ocaml_lwt_interop::promise::Promise<i64> {
+    use ocaml_lwt_interop::domain_executor::{ocaml_runtime, spawn_with_runtime};
+    let (promise, resolver) = ocaml_lwt_interop::promise::Promise::new(gc);
+    let task = spawn_with_runtime(gc, async move {
+        future::yield_now().await;
+        let gc = &ocaml_runtime();
+        resolver.resolve(gc, &val);
+    });
+    task.detach();
+    promise
+}
+
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn lwti_tests_promise_create_err(
+    msg: String,
+) -> ocaml_lwt_interop::promise::Promise<i64> {
+    use ocaml_lwt_interop::domain_executor::{ocaml_runtime, spawn_with_runtime};
+    let (promise, resolver) = ocaml_lwt_interop::promise::Promise::new(gc);
+    let task = spawn_with_runtime(gc, async move {
+        future::yield_now().await;
+        let gc = &ocaml_runtime();
+        resolver.reject(gc, msg);
+    });
+    task.detach();
+    promise
+}
+
+#[ocaml_lwt_interop::func]
+#[ocaml_gen::func]
+pub fn lwti_tests_await_promise(
+    p: ocaml_lwt_interop::promise::Promise<i64>,
+) -> Result<i64, String> {
+    p.await.map_err(|e| e.to_string())
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 //////////               OCaml bindings generation                   //////////
 ///////////////////////////////////////////////////////////////////////////////
@@ -80,5 +142,10 @@ ocaml_gen_bindings! {
         decl_func!(lwti_tests_test2 => "test_2");
         decl_func!(lwti_tests_test_sync_call => "test_sync_call");
         decl_func!(lwti_tests_spawn_lwt => "spawn_lwt");
+        decl_func!(lwti_tests_run_in_ocaml_domain => "run_in_ocaml_domain");
+        decl_func!(lwti_tests_handle => "handle_test");
+        decl_func!(lwti_tests_promise_create => "promise_create");
+        decl_func!(lwti_tests_promise_create_err => "promise_create_err");
+        decl_func!(lwti_tests_await_promise => "await_promise");
     });
 }

--- a/test/Stubs.ml
+++ b/test/Stubs.ml
@@ -4,4 +4,18 @@ module Tests = struct
   external test_2 : (unit -> unit Lwt.t) -> unit Lwt.t = "lwti_tests_test2"
   external test_sync_call : (unit -> unit) -> unit Lwt.t = "lwti_tests_test_sync_call"
   external spawn_lwt : int64 -> int64 Lwt.t = "lwti_tests_spawn_lwt"
+
+  external run_in_ocaml_domain
+    :  (unit -> unit)
+    -> unit Lwt.t
+    = "lwti_tests_run_in_ocaml_domain"
+
+  external handle_test : (unit -> unit Lwt.t) -> unit Lwt.t = "lwti_tests_handle"
+  external promise_create : int64 -> int64 Lwt.t = "lwti_tests_promise_create"
+  external promise_create_err : string -> int64 Lwt.t = "lwti_tests_promise_create_err"
+
+  external await_promise
+    :  int64 Lwt.t
+    -> (int64, string) result Lwt.t
+    = "lwti_tests_await_promise"
 end

--- a/test/test.ml
+++ b/test/test.ml
@@ -22,6 +22,53 @@ let test_spawn_lwt _ () =
   Lwt.return_unit
 ;;
 
+let test_run_in_ocaml_domain _ () =
+  let called = ref false in
+  Tests.run_in_ocaml_domain (fun () -> called := true)
+  >>= fun () ->
+  check bool "callback called" true !called;
+  Lwt.return_unit
+;;
+
+let test_handle _ () =
+  let called = ref false in
+  Tests.handle_test (fun () ->
+    called := true;
+    Lwt.return_unit)
+  >>= fun () ->
+  check bool "async func called" true !called;
+  Lwt.return_unit
+;;
+
+let test_promise_from_rust _ () =
+  Tests.promise_create 5L
+  >>= fun v ->
+  check int64 "promise" 5L v;
+  Lwt.catch
+    (fun () -> Tests.promise_create_err "boom" >>= fun _ -> fail "expected exn")
+    (fun _ -> Lwt.return_unit)
+;;
+
+let test_promise_to_rust _ () =
+  let p, w = Lwt.wait () in
+  Lwt.wakeup_later w 7L;
+  Tests.await_promise p
+  >>= function
+  | Ok v ->
+    check int64 "await" 7L v;
+    Lwt.return_unit
+  | Error msg -> fail msg
+;;
+
+let test_promise_to_rust_err _ () =
+  let p, w = Lwt.wait () in
+  Lwt.wakeup_later_exn w (Failure "err");
+  Tests.await_promise p
+  >>= function
+  | Ok _ -> fail "expected error"
+  | Error _ -> Lwt.return_unit
+;;
+
 let () =
   Lwt_main.run
     (run
@@ -32,6 +79,11 @@ let () =
            ; test_case "test2" `Quick test_test2
            ; test_case "sync_call" `Quick test_sync_call
            ; test_case "spawn_lwt" `Quick test_spawn_lwt
+           ; test_case "run_in_ocaml_domain" `Quick test_run_in_ocaml_domain
+           ; test_case "handle" `Quick test_handle
+           ; test_case "promise_from_rust" `Quick test_promise_from_rust
+           ; test_case "promise_to_rust" `Quick test_promise_to_rust
+           ; test_case "promise_to_rust_err" `Quick test_promise_to_rust_err
            ] )
        ])
 ;;


### PR DESCRIPTION
## Summary
- extend test stubs with new domain executor and promise helpers
- update OCaml stubs and test suite with new cases

## Testing Done
- `cargo fmt --all`
- `opam exec -- dune fmt`
- `cargo clippy --fix --all --offline --allow-dirty -- -D warnings`
- `cargo test --offline`
- `opam exec -- dune build`
- `opam exec -- dune runtest`
