### PR TITLE
[Rust] handle results in spawn_lwt

### DIFF
--- a/test-stubs/src/lib.rs
+++ b/test-stubs/src/lib.rs
@@ -65,7 +65,16 @@ pub fn lwti_tests_test_sync_call(f: OCamlFunc<(), ()>) {
 pub fn lwti_tests_spawn_lwt(val: i64) -> ocaml_lwt_interop::promise::Promise<i64> {
     ocaml_lwt_interop::domain_executor::spawn_lwt(gc, async move {
         future::yield_now().await;
-        val + 1
+        Ok::<_, Box<dyn std::error::Error>>(val + 1)
+    })
+}
+
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn lwti_tests_spawn_lwt_err(_val: i64) -> ocaml_lwt_interop::promise::Promise<i64> {
+    ocaml_lwt_interop::domain_executor::spawn_lwt(gc, async move {
+        future::yield_now().await;
+        Err::<i64, Box<dyn std::error::Error>>(Box::new(std::io::Error::other("boom")))
     })
 }
 
@@ -142,6 +151,7 @@ ocaml_gen_bindings! {
         decl_func!(lwti_tests_test2 => "test_2");
         decl_func!(lwti_tests_test_sync_call => "test_sync_call");
         decl_func!(lwti_tests_spawn_lwt => "spawn_lwt");
+        decl_func!(lwti_tests_spawn_lwt_err => "spawn_lwt_err");
         decl_func!(lwti_tests_run_in_ocaml_domain => "run_in_ocaml_domain");
         decl_func!(lwti_tests_handle => "handle_test");
         decl_func!(lwti_tests_promise_create => "promise_create");

--- a/test/Stubs.ml
+++ b/test/Stubs.ml
@@ -4,6 +4,7 @@ module Tests = struct
   external test_2 : (unit -> unit Lwt.t) -> unit Lwt.t = "lwti_tests_test2"
   external test_sync_call : (unit -> unit) -> unit Lwt.t = "lwti_tests_test_sync_call"
   external spawn_lwt : int64 -> int64 Lwt.t = "lwti_tests_spawn_lwt"
+  external spawn_lwt_err : int64 -> int64 Lwt.t = "lwti_tests_spawn_lwt_err"
 
   external run_in_ocaml_domain
     :  (unit -> unit)

--- a/test/test.ml
+++ b/test/test.ml
@@ -22,6 +22,12 @@ let test_spawn_lwt _ () =
   Lwt.return_unit
 ;;
 
+let test_spawn_lwt_err _ () =
+  Lwt.catch
+    (fun () -> Tests.spawn_lwt_err 0L >>= fun _ -> fail "expected exn")
+    (fun _ -> Lwt.return_unit)
+;;
+
 let test_run_in_ocaml_domain _ () =
   let called = ref false in
   Tests.run_in_ocaml_domain (fun () -> called := true)
@@ -79,6 +85,7 @@ let () =
            ; test_case "test2" `Quick test_test2
            ; test_case "sync_call" `Quick test_sync_call
            ; test_case "spawn_lwt" `Quick test_spawn_lwt
+           ; test_case "spawn_lwt_err" `Quick test_spawn_lwt_err
            ; test_case "run_in_ocaml_domain" `Quick test_run_in_ocaml_domain
            ; test_case "handle" `Quick test_handle
            ; test_case "promise_from_rust" `Quick test_promise_from_rust


### PR DESCRIPTION
## Summary
- allow `spawn_lwt` to process `Result` from Rust tasks
- add error handling in the spawn_lwt path
- test spawn_lwt success and error cases

## Testing Done
- `cargo test --offline`
- `opam exec -- dune build`
- `opam exec -- dune runtest`
